### PR TITLE
Expose handle_window_event as public

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ categories = ["gui"]
 
 [dependencies]
 imgui = { git = "https://github.com/imgui-rs/imgui-rs", version = "0.12" }
-winit = { version = "0.30", default-features = false }
+winit = { version = "0.30.9", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ categories = ["gui"]
 
 [dependencies]
 imgui = "0.12"
-winit = { version = "0.30.9", default-features = false }
+winit = { version = "0.30", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,5 @@ license = "MIT OR Apache-2.0"
 categories = ["gui"]
 
 [dependencies]
-imgui = { git = "https://github.com/imgui-rs/imgui-rs", version = "0.12" }
+imgui = "0.12"
 winit = { version = "0.30.9", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,6 +157,14 @@ impl WinitPlatform {
             _ => (),
         }
     }
+
+    /// Handles a winit window event.
+    ///
+    /// This function performs the following actions (depends on the event):
+    ///
+    /// * window size / dpi factor changes are applied
+    /// * keyboard state is updated
+    /// * mouse state is updated
     pub fn handle_window_event(&mut self, io: &mut Io, window: &Window, event: &WindowEvent) {
         match *event {
             WindowEvent::Resized(physical_size) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,7 @@ impl WinitPlatform {
             _ => (),
         }
     }
-    fn handle_window_event(&mut self, io: &mut Io, window: &Window, event: &WindowEvent) {
+    pub fn handle_window_event(&mut self, io: &mut Io, window: &Window, event: &WindowEvent) {
         match *event {
             WindowEvent::Resized(physical_size) => {
                 let logical_size = physical_size.to_logical(window.scale_factor());


### PR DESCRIPTION
Since `winit::application::ApplicationHandler` exposes `window_event`, this would integrate it nicely to the trait.